### PR TITLE
Adding ignoredUnusedImportPaths to sortConfiguration

### DIFF
--- a/src/core/models/sort-configuration.ts
+++ b/src/core/models/sort-configuration.ts
@@ -14,6 +14,7 @@ export interface SortConfiguration {
     };
     joinImportPaths?: boolean;
     removeUnusedImports?: boolean;
+    ignoredUnusedImportPaths?: string[];
     customOrderingRules?: {
         defaultOrderLevel: number;
         disableDefaultOrderSort?: boolean;
@@ -33,6 +34,7 @@ export const defaultSortConfiguration: SortConfiguration = {
     },
     joinImportPaths: true,
     removeUnusedImports: false,
+    ignoredUnusedImportPaths: [],
     customOrderingRules: {
         defaultOrderLevel: 20,
         defaultNumberOfEmptyLinesAfterGroup: 1,


### PR DESCRIPTION
In files that are using JSX, React has to be imported, even if it's not used explicitly. For cases like that one, I've added `ignoredUnusedImportPaths`, array of paths that should be ignored when removing unused imports.