### PR TITLE
add support for javascript and javascriptreact

### DIFF
--- a/src/core/allowed-languages.ts
+++ b/src/core/allowed-languages.ts
@@ -1,0 +1,8 @@
+import { AllowedLanguage } from "./models/models-public";
+
+export const allowedLanguages: AllowedLanguage[] = [
+  { id: "javascript", fileExtension: "js" },
+  { id: "javascriptreact", fileExtension: "jsx" },
+  { id: "typescript", fileExtension: "ts" },
+  { id: "typescriptreact", fileExtension: "tsx" }
+];

--- a/src/core/core-public.ts
+++ b/src/core/core-public.ts
@@ -3,3 +3,4 @@ export * from './ast-parser';
 export * from './import-creator';
 export * from './import-sorter';
 export * from './import-runner';
+export * from './allowed-languages';

--- a/src/core/helpers/forbidden-language-error.ts
+++ b/src/core/helpers/forbidden-language-error.ts
@@ -1,0 +1,9 @@
+import { allowedLanguages } from "../allowed-languages";
+
+export const forbiddenLanguageError = "Import Sorter currently only supports "
+    .concat(
+        allowedLanguages
+            .map(({ id, fileExtension }) => `${id} .(${fileExtension}) `)
+            .join("or ")
+    )
+    .concat("language files");

--- a/src/core/helpers/helpers-public.ts
+++ b/src/core/helpers/helpers-public.ts
@@ -1,3 +1,5 @@
 import * as io from './io';
 import * as textProcessing from './text-processing';
+
 export { io, textProcessing };
+export * from './forbidden-language-error';

--- a/src/core/import-runner.ts
+++ b/src/core/import-runner.ts
@@ -14,6 +14,7 @@ import {
     ImportElement, ImportElementGroup, ImportSorterConfiguration, LineRange, SortedImportData
 } from './models/models-public';
 import { textProcessing } from './helpers/helpers-public';
+import { allowedLanguages } from './allowed-languages';
 
 export interface ConfigurationProvider {
     getConfiguration(): ImportSorterConfiguration;
@@ -193,7 +194,7 @@ export class SimpleImportRunner implements ImportRunner {
             throw new Error('No directory selected.');
         }
 
-        const allFilesPatterns = ['**/*.ts', '**/*.tsx'];
+        const allFilesPatterns = allowedLanguages.map(({ fileExtension }) => `**/*.${fileExtension}`);
         const ignore = [];
         const filesPaths$ = allFilesPatterns.map(pattern => io.filePaths$(startingSourcePath, pattern, ignore));
         return mergeObservable(...filesPaths$);

--- a/src/core/models/allowed-language.ts
+++ b/src/core/models/allowed-language.ts
@@ -1,0 +1,4 @@
+export interface AllowedLanguage {
+  id: string;
+  fileExtension: string;
+}

--- a/src/core/models/models-public.ts
+++ b/src/core/models/models-public.ts
@@ -10,3 +10,4 @@ export * from './sort-configuration';
 export * from './import-element-group';
 export * from './import-element-sort-result';
 export * from './import-sorter-configuration';
+export * from './allowed-language';

--- a/src/import-sorter-extension.ts
+++ b/src/import-sorter-extension.ts
@@ -10,8 +10,10 @@ import {
 import {
     defaultGeneralConfiguration, GeneralConfiguration, ImportRunner, ImportSorterConfiguration,
     ImportStringConfiguration, InMemoryImportCreator, InMemoryImportSorter, SimpleImportAstParser,
-    SimpleImportRunner, SortConfiguration
+    SimpleImportRunner, SortConfiguration,
+    allowedLanguages
 } from './core/core-public';
+import { forbiddenLanguageError } from './core/helpers/helpers-public';
 import { ConfigurationProvider } from './core/import-runner';
 
 const EXTENSION_CONFIGURATION_NAME = 'importSorter';
@@ -175,7 +177,7 @@ export class ImportSorterExtension {
             return false;
         }
 
-        if ((document.languageId === 'typescript') || (document.languageId === 'typescriptreact')) {
+        if(allowedLanguages.some(({ fileExtension }) => document.languageId === fileExtension)) {
             return true;
         }
 
@@ -183,7 +185,7 @@ export class ImportSorterExtension {
             return false;
         }
 
-        window.showErrorMessage('Import Sorter currently only supports typescript (.ts) or typescriptreact (.tsx) language files');
+        window.showErrorMessage(forbiddenLanguageError);
         return false;
     }
 }


### PR DESCRIPTION
Supporting typescript is basically supporting all of javascript + the additions typescript brings to the table - so why not support them both?

I've created a neat little PR that generalizes supported languages of this extension and allows for easy addition of new languages by altering **only one** file!